### PR TITLE
fix: resolve serialization error in tracking and add wiki link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ vendor/
 Thumbs.db
 *.swp
 *.swo
+backlog/

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Publish the configuration file:
 php artisan vendor:publish --tag="apiroute-config"
 ```
 
+## Documentation
+
+For complete documentation including migrations, advanced configuration, and usage tracking setup, please visit the **[Wiki](https://github.com/Grazulex/laravel-apiroute/wiki)**.
+
 ## Quick Start
 
 Define your API versions in `routes/api.php`:

--- a/src/Middleware/TrackApiUsage.php
+++ b/src/Middleware/TrackApiUsage.php
@@ -26,13 +26,19 @@ class TrackApiUsage
         $version = $request->attributes->get('api_version');
 
         if ($version !== null) {
+            // Extract primitive values before dispatch to avoid serialization issues
+            // The request contains VersionDefinition with Closure properties that cannot be serialized
+            $endpoint = $request->path();
+            $method = $request->method();
+            $statusCode = $response->getStatusCode();
+
             // Track after response for performance
-            dispatch(function () use ($request, $response, $version): void {
+            dispatch(function () use ($version, $endpoint, $method, $statusCode): void {
                 $this->tracker->track(
                     version: $version,
-                    endpoint: $request->path(),
-                    method: $request->method(),
-                    status: $response->getStatusCode()
+                    endpoint: $endpoint,
+                    method: $method,
+                    status: $statusCode
                 );
             })->afterResponse();
         }


### PR DESCRIPTION
## Summary

- **Fix #4**: Resolved serialization error when tracking API usage by extracting primitive values before the dispatch closure. The Request object contained a VersionDefinition with Closure properties that cannot be serialized by Laravel's queue system.
- **Fix #3**: Added documentation section in README pointing users to the wiki for complete documentation (migrations, tracking setup, etc.).
- Added `backlog/` to `.gitignore`

## Changes

### `src/Middleware/TrackApiUsage.php`
Extract `$endpoint`, `$method`, and `$statusCode` as primitive values before passing them to the `dispatch()` closure, instead of capturing the entire `$request` and `$response` objects.

### `README.md`
Added "Documentation" section with link to wiki for complete documentation.

## Test plan

- [ ] Verify tracking works with `dispatch()->afterResponse()` when `QUEUE_CONNECTION=sync`
- [ ] Confirm no serialization errors occur
- [ ] Check wiki link in README works

Closes #3, closes #4