### PR TITLE
chore(release): 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.0](https://github.com/Grazulex/laravel-apiroute/releases/tag/v1.2.0) (2025-12-28)
+
+### Bug Fixes
+
+- resolve SQL upsert error in DatabaseTracker ([a0ba167](https://github.com/Grazulex/laravel-apiroute/commit/a0ba167f6e1eeaee513c1c379579707d33c2edb6))
 ## [1.1.0](https://github.com/Grazulex/laravel-apiroute/releases/tag/v1.1.0) (2025-12-28)
 
 ### Bug Fixes


### PR DESCRIPTION
## Summary

- Release version 1.2.0

## Changes since 1.1.0

- fix: resolve SQL upsert error in DatabaseTracker (#8)
  - Fixed `SQLSTATE[HY000]: General error: 1 no such column: requests_count` with SQLite
  - Now works consistently across all database drivers