### PR TITLE
fix: add API version headers to error responses

### DIFF
--- a/src/Listeners/AddVersionHeadersToResponse.php
+++ b/src/Listeners/AddVersionHeadersToResponse.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Grazulex\ApiRoute\Listeners;
+
+use Grazulex\ApiRoute\Http\Headers\VersionHeaders;
+use Grazulex\ApiRoute\Support\ApiVersionContext;
+use Illuminate\Foundation\Http\Events\RequestHandled;
+
+/**
+ * Listener that adds API version headers to all responses.
+ *
+ * This listener is triggered after the response is created but before it's sent,
+ * ensuring that version headers are added to ALL responses including error responses
+ * (401, 403, 404, 500, etc.).
+ */
+class AddVersionHeadersToResponse
+{
+    public function __construct(
+        private readonly ApiVersionContext $context,
+        private readonly VersionHeaders $headers
+    ) {}
+
+    /**
+     * Handle the RequestHandled event.
+     */
+    public function handle(RequestHandled $event): void
+    {
+        // Only add headers if a version was resolved
+        if (! $this->context->hasVersion()) {
+            return;
+        }
+
+        $version = $this->context->getVersion();
+        $request = $this->context->getRequest();
+
+        if ($version === null) {
+            return;
+        }
+
+        // Add version headers to the response
+        $this->headers->addToResponse($event->response, $version, $request);
+    }
+}

--- a/src/Support/ApiVersionContext.php
+++ b/src/Support/ApiVersionContext.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Grazulex\ApiRoute\Support;
+
+use Grazulex\ApiRoute\VersionDefinition;
+use Illuminate\Http\Request;
+
+/**
+ * Singleton that holds the resolved API version context.
+ *
+ * This class stores the resolved version information so it can be accessed
+ * by listeners and exception handlers to add version headers to all responses,
+ * including error responses.
+ */
+class ApiVersionContext
+{
+    private ?VersionDefinition $version = null;
+
+    private ?Request $request = null;
+
+    /**
+     * Set the resolved version context.
+     */
+    public function set(VersionDefinition $version, Request $request): void
+    {
+        $this->version = $version;
+        $this->request = $request;
+    }
+
+    /**
+     * Get the resolved version definition.
+     */
+    public function getVersion(): ?VersionDefinition
+    {
+        return $this->version;
+    }
+
+    /**
+     * Get the original request.
+     */
+    public function getRequest(): ?Request
+    {
+        return $this->request;
+    }
+
+    /**
+     * Check if a version has been resolved.
+     */
+    public function hasVersion(): bool
+    {
+        return $this->version !== null;
+    }
+
+    /**
+     * Clear the context (useful for testing).
+     */
+    public function clear(): void
+    {
+        $this->version = null;
+        $this->request = null;
+    }
+}

--- a/tests/Feature/ErrorResponseHeadersTest.php
+++ b/tests/Feature/ErrorResponseHeadersTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+use Carbon\Carbon;
+use Grazulex\ApiRoute\Facades\ApiRoute;
+use Illuminate\Support\Facades\Route;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+
+/**
+ * Tests for API version headers on error responses.
+ *
+ * These tests verify that X-API-Version and X-API-Version-Status headers
+ * are added to ALL responses, including error responses (401, 403, 404, 500, etc.).
+ *
+ * @see https://github.com/Grazulex/laravel-apiroute/issues/16
+ */
+test('adds version headers to 401 unauthorized response', function () {
+    ApiRoute::version('v1', function () {
+        Route::get('protected', function () {
+            throw new UnauthorizedHttpException('Bearer', 'Unauthenticated.');
+        });
+    });
+
+    $response = $this->get('/api/v1/protected');
+
+    $response->assertUnauthorized();
+    $response->assertHeader('X-API-Version', 'v1');
+    $response->assertHeader('X-API-Version-Status', 'active');
+});
+
+test('adds version headers to 403 forbidden response', function () {
+    ApiRoute::version('v1', function () {
+        Route::get('forbidden', function () {
+            throw new AccessDeniedHttpException('Access denied.');
+        });
+    });
+
+    $response = $this->get('/api/v1/forbidden');
+
+    $response->assertForbidden();
+    $response->assertHeader('X-API-Version', 'v1');
+    $response->assertHeader('X-API-Version-Status', 'active');
+});
+
+test('adds version headers to 404 not found response', function () {
+    ApiRoute::version('v1', function () {
+        Route::get('missing', function () {
+            throw new NotFoundHttpException('Resource not found.');
+        });
+    });
+
+    $response = $this->get('/api/v1/missing');
+
+    $response->assertNotFound();
+    $response->assertHeader('X-API-Version', 'v1');
+    $response->assertHeader('X-API-Version-Status', 'active');
+});
+
+test('adds version headers to 500 server error response', function () {
+    ApiRoute::version('v1', function () {
+        Route::get('error', function () {
+            throw new \RuntimeException('Internal server error.');
+        });
+    });
+
+    $response = $this->get('/api/v1/error');
+
+    $response->assertServerError();
+    $response->assertHeader('X-API-Version', 'v1');
+    $response->assertHeader('X-API-Version-Status', 'active');
+});
+
+test('adds version headers to 410 sunset response', function () {
+    ApiRoute::version('v1', function () {
+        Route::get('test', fn () => response()->json(['ok' => true]));
+    })->sunset(Carbon::now()->subDay());
+
+    $response = $this->get('/api/v1/test');
+
+    $response->assertStatus(410);
+    $response->assertHeader('X-API-Version', 'v1');
+    $response->assertHeader('X-API-Version-Status', 'sunset');
+});
+
+test('adds deprecation headers to error response for deprecated version', function () {
+    ApiRoute::version('v1', function () {
+        Route::get('error', function () {
+            throw new NotFoundHttpException('Not found.');
+        });
+    })->deprecated('2025-06-01');
+
+    $response = $this->get('/api/v1/error');
+
+    $response->assertNotFound();
+    $response->assertHeader('X-API-Version', 'v1');
+    $response->assertHeader('X-API-Version-Status', 'deprecated');
+    $response->assertHeader('Deprecation');
+});
+
+test('adds sunset header to error response when sunset date is set', function () {
+    ApiRoute::version('v1', function () {
+        Route::get('error', function () {
+            throw new NotFoundHttpException('Not found.');
+        });
+    })->deprecated('2025-06-01')->sunset('2099-12-01');
+
+    $response = $this->get('/api/v1/error');
+
+    $response->assertNotFound();
+    $response->assertHeader('X-API-Version', 'v1');
+    $response->assertHeader('Sunset');
+});
+
+test('adds successor link header to error response', function () {
+    ApiRoute::version('v1', function () {
+        Route::get('error', function () {
+            throw new NotFoundHttpException('Not found.');
+        });
+    })->deprecated('2025-06-01')->setSuccessor('v2');
+
+    $response = $this->get('/api/v1/error');
+
+    $response->assertNotFound();
+    $response->assertHeader('Link');
+    expect($response->headers->get('Link'))->toContain('successor-version');
+});
+
+test('version headers can be disabled for error responses', function () {
+    config(['apiroute.headers.enabled' => false]);
+
+    ApiRoute::version('v1', function () {
+        Route::get('error', function () {
+            throw new NotFoundHttpException('Not found.');
+        });
+    });
+
+    $response = $this->get('/api/v1/error');
+
+    $response->assertNotFound();
+    expect($response->headers->has('X-API-Version'))->toBeFalse();
+    expect($response->headers->has('X-API-Version-Status'))->toBeFalse();
+});
+
+test('does not add headers when version is not resolved', function () {
+    // Request to a non-existent version - VersionNotFoundException is thrown
+    // before the version can be stored in the context
+    ApiRoute::version('v1', function () {
+        Route::get('test', fn () => response()->json(['ok' => true]));
+    });
+
+    $response = $this->get('/api/v999/test');
+
+    $response->assertNotFound();
+    // Headers should NOT be present because the version was never resolved
+    expect($response->headers->has('X-API-Version'))->toBeFalse();
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Grazulex\ApiRoute\Tests;
 
 use Grazulex\ApiRoute\ApiRouteServiceProvider;
+use Grazulex\ApiRoute\Support\ApiVersionContext;
 use Orchestra\Testbench\TestCase as Orchestra;
 
 abstract class TestCase extends Orchestra
@@ -12,6 +13,11 @@ abstract class TestCase extends Orchestra
     protected function setUp(): void
     {
         parent::setUp();
+
+        // Clear the API version context between tests to avoid state leakage
+        if ($this->app->bound(ApiVersionContext::class)) {
+            $this->app->make(ApiVersionContext::class)->clear();
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- Add version headers (X-API-Version, X-API-Version-Status, Deprecation, Sunset, Link) to ALL HTTP responses including error responses (401, 403, 404, 500, etc.)
- Fix issue where headers were missing on authentication errors and other exceptions
- Add ApiVersionContext singleton to store resolved version early in request lifecycle
- Add AddVersionHeadersToResponse listener on RequestHandled event

## Technical Changes
| File | Change |
|------|--------|
| `src/Support/ApiVersionContext.php` | New singleton to store resolved version |
| `src/Listeners/AddVersionHeadersToResponse.php` | New listener on RequestHandled event |
| `src/Middleware/ResolveApiVersion.php` | Store version in context before exceptions |
| `src/ApiRouteServiceProvider.php` | Register singleton and event listener |
| `tests/TestCase.php` | Clear context between tests |
| `tests/Feature/ErrorResponseHeadersTest.php` | 10 new tests for error response headers |

## Test plan
- [x] 83 tests passing
- [x] Pint formatting OK
- [x] PHPStan analysis OK
- [x] Headers verified on: 401, 403, 404, 500, 410 responses
- [x] Headers verified on deprecated version error responses
- [x] Headers verified with sunset date on error responses

Closes #16