### PR TITLE
fix: add fallback version resolution in response listener

### DIFF
--- a/src/Listeners/AddVersionHeadersToResponse.php
+++ b/src/Listeners/AddVersionHeadersToResponse.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace Grazulex\ApiRoute\Listeners;
 
+use Grazulex\ApiRoute\Contracts\VersionResolverInterface;
 use Grazulex\ApiRoute\Http\Headers\VersionHeaders;
 use Grazulex\ApiRoute\Support\ApiVersionContext;
+use Grazulex\ApiRoute\VersionDefinition;
 use Illuminate\Foundation\Http\Events\RequestHandled;
+use Illuminate\Http\Request;
 
 /**
  * Listener that adds API version headers to all responses.
@@ -19,7 +22,8 @@ class AddVersionHeadersToResponse
 {
     public function __construct(
         private readonly ApiVersionContext $context,
-        private readonly VersionHeaders $headers
+        private readonly VersionHeaders $headers,
+        private readonly VersionResolverInterface $resolver
     ) {}
 
     /**
@@ -27,13 +31,8 @@ class AddVersionHeadersToResponse
      */
     public function handle(RequestHandled $event): void
     {
-        // Only add headers if a version was resolved
-        if (! $this->context->hasVersion()) {
-            return;
-        }
-
-        $version = $this->context->getVersion();
-        $request = $this->context->getRequest();
+        $request = $event->request;
+        $version = $this->resolveVersion($request);
 
         if ($version === null) {
             return;
@@ -41,5 +40,48 @@ class AddVersionHeadersToResponse
 
         // Add version headers to the response
         $this->headers->addToResponse($event->response, $version, $request);
+    }
+
+    /**
+     * Resolve the version from multiple sources for maximum compatibility.
+     *
+     * This method tries multiple approaches to ensure headers are added
+     * even in edge cases like cached routes or middleware execution issues.
+     */
+    private function resolveVersion(Request $request): ?VersionDefinition
+    {
+        // 1. Try from context (set by middleware)
+        if ($this->context->hasVersion()) {
+            return $this->context->getVersion();
+        }
+
+        // 2. Try from request attributes (also set by middleware)
+        $version = $request->attributes->get('api_version_definition');
+        if ($version instanceof VersionDefinition) {
+            return $version;
+        }
+
+        // 3. Check if this looks like an API version request
+        // Only try to resolve if the path contains a version pattern
+        $path = $request->path();
+        if (! preg_match('/\bv\d+\b/i', $path)) {
+            return null;
+        }
+
+        // 4. Try to resolve directly from request (fallback for edge cases)
+        // This handles scenarios where middleware didn't execute or context was lost
+        // Only proceed if the version actually exists (don't fall back to other versions)
+        $resolved = $this->resolver->resolve($request);
+
+        // Verify the resolved version matches what was requested
+        // to avoid adding headers for fallback versions on non-existent version requests
+        if ($resolved !== null) {
+            $requestedVersion = $this->resolver->getRequestedVersion($request);
+            if ($requestedVersion !== null && $resolved->name() === $requestedVersion) {
+                return $resolved;
+            }
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
## Summary

This PR enhances the `AddVersionHeadersToResponse` listener to be more resilient in edge cases where the version context might not be populated.

### Changes

The listener now tries multiple approaches to resolve the API version:
1. **From ApiVersionContext singleton** - The primary source, set by the `api.version` middleware
2. **From request attributes** - Also set by middleware, provides redundancy
3. **Direct resolution from request URI** - Fallback for edge cases where context might be lost

### Why this is needed

In certain environments (cached routes, specific middleware configurations, Laravel Octane), the ApiVersionContext singleton might not be properly populated when the listener runs. This fallback ensures headers are added correctly even in these edge cases.

### Safeguards

- The fallback only adds headers when the requested version actually exists
- Prevents incorrect headers on requests to non-existent versions (e.g., `/api/v999/test` won't get X-API-Version headers)
- Maintains backward compatibility with existing behavior

Closes #16

## Test plan

- [x] All 83 existing tests pass
- [x] PHPStan static analysis passes
- [x] Pint code style passes