### PR TITLE
feat: add subdomain-based API routing support

### DIFF
--- a/config/apiroute.php
+++ b/config/apiroute.php
@@ -48,8 +48,9 @@ return [
     */
     'strategies' => [
         'uri' => [
-            'prefix' => 'api',           // /api/v1/users
+            'prefix' => 'api',           // /api/v1/users (use '' for no prefix)
             'pattern' => 'v{version}',   // v1, v2, etc.
+            'domain' => null,            // null or 'api.example.com' for subdomain routing
         ],
         'header' => [
             'name' => 'X-API-Version',   // X-API-Version: 1

--- a/src/ApiRouteManager.php
+++ b/src/ApiRouteManager.php
@@ -185,10 +185,19 @@ class ApiRouteManager
         /** @var array<string, mixed> $uriConfig */
         $uriConfig = config('apiroute.strategies.uri', []);
 
-        $prefix = ($uriConfig['prefix'] ?? 'api') . '/' . $definition->name();
+        $prefix = $uriConfig['prefix'] ?? 'api';
+        $domain = $uriConfig['domain'] ?? null;
 
-        $routeGroup = Route::prefix($prefix)
+        // Build prefix: include version name
+        $fullPrefix = $prefix !== '' ? $prefix . '/' . $definition->name() : $definition->name();
+
+        $routeGroup = Route::prefix($fullPrefix)
             ->middleware($this->getMiddleware($definition));
+
+        // Apply domain if configured (for subdomain-based routing)
+        if ($domain !== null && $domain !== '') {
+            $routeGroup->domain($domain);
+        }
 
         // Apply route name prefix if defined
         $routeName = $definition->routeName();
@@ -208,9 +217,15 @@ class ApiRouteManager
         $uriConfig = config('apiroute.strategies.uri', []);
 
         $prefix = $uriConfig['prefix'] ?? 'api';
+        $domain = $uriConfig['domain'] ?? null;
 
         $routeGroup = Route::prefix($prefix)
             ->middleware($this->getMiddleware($definition));
+
+        // Apply domain if configured (for subdomain-based routing)
+        if ($domain !== null && $domain !== '') {
+            $routeGroup->domain($domain);
+        }
 
         // Apply route name prefix if defined
         $routeName = $definition->routeName();

--- a/tests/Feature/SubdomainRoutingTest.php
+++ b/tests/Feature/SubdomainRoutingTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+use Grazulex\ApiRoute\ApiRouteManager;
+use Grazulex\ApiRoute\Facades\ApiRoute;
+use Illuminate\Support\Facades\Route;
+
+test('routes can be registered with subdomain', function () {
+    config([
+        'apiroute.strategies.uri.domain' => 'api.example.com',
+        'apiroute.strategies.uri.prefix' => '',
+    ]);
+
+    $manager = app(ApiRouteManager::class);
+    $manager->reset();
+
+    ApiRoute::version('v1', function () {
+        Route::get('users', fn () => response()->json(['version' => 'v1']));
+    });
+
+    // Check that routes were registered
+    $routes = Route::getRoutes();
+    $route = $routes->getByName(null);
+
+    // Find the route matching our pattern
+    $found = false;
+    foreach ($routes as $route) {
+        if (str_contains($route->uri(), 'v1/users')) {
+            $found = true;
+            expect($route->getDomain())->toBe('api.example.com');
+            break;
+        }
+    }
+
+    expect($found)->toBeTrue();
+});
+
+test('routes work with empty prefix and subdomain', function () {
+    config([
+        'apiroute.strategies.uri.domain' => 'api.example.com',
+        'apiroute.strategies.uri.prefix' => '',
+    ]);
+
+    $manager = app(ApiRouteManager::class);
+    $manager->reset();
+
+    ApiRoute::version('v1', function () {
+        Route::get('test', fn () => response()->json(['version' => 'v1']));
+    });
+
+    // The route should be /v1/test (no /api prefix)
+    $routes = Route::getRoutes();
+    $found = false;
+    foreach ($routes as $route) {
+        if ($route->uri() === 'v1/test') {
+            $found = true;
+            expect($route->getDomain())->toBe('api.example.com');
+            break;
+        }
+    }
+
+    expect($found)->toBeTrue();
+});
+
+test('routes work with prefix and subdomain combined', function () {
+    config([
+        'apiroute.strategies.uri.domain' => 'api.example.com',
+        'apiroute.strategies.uri.prefix' => 'v1-api',
+    ]);
+
+    $manager = app(ApiRouteManager::class);
+    $manager->reset();
+
+    ApiRoute::version('v1', function () {
+        Route::get('users', fn () => response()->json(['version' => 'v1']));
+    });
+
+    // The route should be /v1-api/v1/users with domain
+    $routes = Route::getRoutes();
+    $found = false;
+    foreach ($routes as $route) {
+        if ($route->uri() === 'v1-api/v1/users') {
+            $found = true;
+            expect($route->getDomain())->toBe('api.example.com');
+            break;
+        }
+    }
+
+    expect($found)->toBeTrue();
+});
+
+test('routes work without domain (backward compatibility)', function () {
+    config([
+        'apiroute.strategies.uri.domain' => null,
+        'apiroute.strategies.uri.prefix' => 'api',
+    ]);
+
+    $manager = app(ApiRouteManager::class);
+    $manager->reset();
+
+    ApiRoute::version('v1', function () {
+        Route::get('users', fn () => response()->json(['version' => 'v1']));
+    });
+
+    // The route should be /api/v1/users without domain
+    $routes = Route::getRoutes();
+    $found = false;
+    foreach ($routes as $route) {
+        if ($route->uri() === 'api/v1/users') {
+            $found = true;
+            expect($route->getDomain())->toBeNull();
+            break;
+        }
+    }
+
+    expect($found)->toBeTrue();
+});
+
+test('empty string domain is treated as no domain', function () {
+    config([
+        'apiroute.strategies.uri.domain' => '',
+        'apiroute.strategies.uri.prefix' => 'api',
+    ]);
+
+    $manager = app(ApiRouteManager::class);
+    $manager->reset();
+
+    ApiRoute::version('v1', function () {
+        Route::get('test', fn () => response()->json(['version' => 'v1']));
+    });
+
+    $routes = Route::getRoutes();
+    foreach ($routes as $route) {
+        if ($route->uri() === 'api/v1/test') {
+            expect($route->getDomain())->toBeNull();
+            break;
+        }
+    }
+});
+
+test('non-uri strategy also supports domain', function () {
+    config([
+        'apiroute.strategy' => 'header',
+        'apiroute.strategies.uri.domain' => 'api.example.com',
+        'apiroute.strategies.uri.prefix' => '',
+    ]);
+
+    $manager = app(ApiRouteManager::class);
+    $manager->reset();
+
+    ApiRoute::version('v1', function () {
+        Route::get('users', fn () => response()->json(['version' => 'v1']));
+    });
+
+    $routes = Route::getRoutes();
+    $found = false;
+    foreach ($routes as $route) {
+        if ($route->uri() === 'users') {
+            $found = true;
+            expect($route->getDomain())->toBe('api.example.com');
+            break;
+        }
+    }
+
+    expect($found)->toBeTrue();
+});


### PR DESCRIPTION
## Summary

- Add support for subdomain-based API routing (e.g., `api.example.com/v1/users`) without requiring the `/api` URL prefix
- Add `domain` option to `strategies.uri` config
- Support empty prefix for cleaner URLs
- Apply `Route::domain()` when domain is configured
- Works with both URI and non-URI strategies

## Configuration Example

```php
'strategies' => [
    'uri' => [
        'prefix' => '',                    // No prefix
        'pattern' => 'v{version}',
        'domain' => 'api.example.com',     // Your API subdomain
    ],
],
```

## Test plan

- [x] Routes can be registered with subdomain
- [x] Routes work with empty prefix and subdomain
- [x] Routes work with prefix and subdomain combined
- [x] Backward compatibility (no domain = current behavior)
- [x] Empty string domain treated as no domain
- [x] Non-URI strategies also support domain

All 89 tests passing.

Closes #22