### PR TITLE
fix: correct VersionTrackerInterface singleton $app type hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.1.1](https://github.com/Grazulex/laravel-apiroute/releases/tag/v2.1.1) (2026-08-07)
+
+### Bug Fixes
+
+- fix VersionTrackerInterface singleton $app type hint to prevent TypeError in Laravel 12/13 (#27)
 ## [2.0.3](https://github.com/Grazulex/laravel-apiroute/releases/tag/v2.0.3) (2026-01-03)
 
 ### Bug Fixes

--- a/src/ApiRouteServiceProvider.php
+++ b/src/ApiRouteServiceProvider.php
@@ -22,6 +22,7 @@ use Grazulex\ApiRoute\Support\VersionStatus;
 use Grazulex\ApiRoute\Tracking\DatabaseTracker;
 use Grazulex\ApiRoute\Tracking\NullTracker;
 use Grazulex\ApiRoute\Tracking\RedisTracker;
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Foundation\Http\Events\RequestHandled;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
@@ -48,7 +49,7 @@ class ApiRouteServiceProvider extends ServiceProvider
 
         $this->app->singleton(ApiVersionContext::class);
 
-        $this->app->singleton(VersionTrackerInterface::class, function (array $app): VersionTrackerInterface {
+        $this->app->singleton(VersionTrackerInterface::class, function (Application $app): VersionTrackerInterface {
             /** @var array<string, mixed> $trackingConfig */
             $trackingConfig = $app['config']['apiroute.tracking'] ?? [];
 


### PR DESCRIPTION
## Summary

Fixes #27. The VersionTrackerInterface singleton closure in ApiRouteServiceProvider::register() declared $app as array, but Laravel's container passes an Illuminate\Foundation\Application instance, causing a TypeError.

## Changes

- Change function (array $app) to function (Application $app) and import Illuminate\Contracts\Foundation\Application. Access via $app['config'] still works since Application implements ArrayAccess.
- Add 2.1.1 changelog entry.

## Test plan

- [x] Pest: 93 tests, 251 assertions pass
- [x] PHPStan: no errors
- [x] Pint: passed

Closes #27